### PR TITLE
Dev pet weaponskill

### DIFF
--- a/PUP.lua
+++ b/PUP.lua
@@ -1111,7 +1111,8 @@ windower.register_event(
             --then we may equip Weaponskill Gear for pet
             --Otherwise this is handled when player has more TP in aftercast
             if pet.isvalid and 
-            (player.tp < 1000 or state.PetStyleCycle.value:lower() == "spam" or state.PetStyleCycle.value:lower() == "dd") then
+            (player.tp < 1000 or state.PetStyleCycle.value:lower() == "spam" or state.PetStyleCycle.value:lower() == "dd")
+            and Master_State:lower() == "idle" then
                 --Now if pet has more than 1000 tp and pet is engaged and didn't just finish a weaponskill
                 --Then we may equip the Weaponskill gear for pet
                 if pet.tp >= 1000 and Pet_State == const_stateEngaged and justFinishedWeaponSkill == false then

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ You can hide the State from the Window by using the below command:
 You can hide the Mode from the Window by using the below command
 - `//gs c hide mode`
 
+You can toggle default keybinds set up for cycles/modes on menu by using the below command
+- `//gs c hide keybinds`
+
 ## Notes On Pet Equipping Weaponskill Gear
 This is currently how we determine when to equip a pets Weaponskill Gear prior to it using:
 


### PR DESCRIPTION
This adjust a issue with the Weaponskill for the puppet not staying equipped when a player uses a weaponskill. 

Also, this adds the ability to toggle next to Pet Mode, Pet Style, Options, etc... the default keybinds on the UI Window. 